### PR TITLE
Avoid clickbaity thumbnails

### DIFF
--- a/lib/youtube.js
+++ b/lib/youtube.js
@@ -94,7 +94,7 @@ export async function getVideosFor(channelName) {
       channelName,
       title: data.title?.runs[0].text,
       url: `https://www.youtube.com/watch?v=${data.videoId}`, 
-      thumbnail: `https://img.youtube.com/vi/${data.videoId}/mqdefault.jpg`,
+      thumbnail: `https://img.youtube.com/vi/${data.videoId}/mq2.jpg`,
       description: data.descriptionSnippet?.runs[0].text,
       id: data.videoId,
       publishedTime: data.publishedTimeText?.simpleText,


### PR DESCRIPTION
Changed the thumbnail image to one that isn't full of nonsensical CLICKBAIT11!!ELEVEN!! text and 😮 faces.

This is the quick-n-dirty way of doing it...might add it as a user preference later on.